### PR TITLE
Fixed missing return value bug in sr030pc50 camera driver.

### DIFF
--- a/drivers/media/video/msm/sr030pc50.c
+++ b/drivers/media/video/msm/sr030pc50.c
@@ -1005,8 +1005,7 @@ static int sr030pc50_set_preview(void)
                 CAMDRV_DEBUG("[%s : %d]Same setting before and now\n",
                         __func__, __LINE__);
                 sr030pc50_WRITE_LIST(sr030pc50_update_preview_setting);
-                return;
-
+                return 0;
         }
 
         if (mDTP == 1) {


### PR DESCRIPTION
Fixes front camera preview hang after taking a picture in CM11 Camera application.
